### PR TITLE
유저 로직 수정

### DIFF
--- a/danggunMarket/src/main/java/com/example/danggunmarket/common/config/SecurityConfig.java
+++ b/danggunMarket/src/main/java/com/example/danggunmarket/common/config/SecurityConfig.java
@@ -53,9 +53,10 @@ public class SecurityConfig {
                     .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
             return LoggedInMember.builder()
-                    .id(member.getId())
+                    .id(member.getMemberId())
                     .role(member.getRole())
                     .nickname(member.getNickname())
+                    .email(member.getEmail())
                     .build();
         };
     }
@@ -76,7 +77,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder(){
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 }

--- a/danggunMarket/src/main/java/com/example/danggunmarket/member/MemberController.java
+++ b/danggunMarket/src/main/java/com/example/danggunmarket/member/MemberController.java
@@ -41,7 +41,7 @@ public class MemberController {
     public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest, HttpServletResponse response){
         LoginResponse loginResponse = memberService.login(loginRequest);
 
-        response.addHeader("Authorization", jwtUtil.createToken(loginResponse.getEmail()));
+        response.addHeader("Authorization", "Bearer " + jwtUtil.createToken(loginResponse.getEmail()));
 
         return ResponseEntity.ok(loginResponse);
     }

--- a/danggunMarket/src/main/java/com/example/danggunmarket/member/MemberEntity.java
+++ b/danggunMarket/src/main/java/com/example/danggunmarket/member/MemberEntity.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 public class MemberEntity extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private long memberId;
     private String name;
 
     @Column(unique = true)
@@ -26,6 +26,7 @@ public class MemberEntity extends BaseEntity {
     private String password;
     private String telNumber;
 
+    @Enumerated(EnumType.STRING)
     private MemberRole role;
     @Embedded
     private Address homeAddress;

--- a/danggunMarket/src/main/java/com/example/danggunmarket/member/MemberService.java
+++ b/danggunMarket/src/main/java/com/example/danggunmarket/member/MemberService.java
@@ -5,6 +5,7 @@ import com.example.danggunmarket.member.dto.LoginRequest;
 import com.example.danggunmarket.member.dto.LoginResponse;
 import com.example.danggunmarket.member.exception.AlreadyExistException;
 import com.example.danggunmarket.member.exception.MemberErrorCode;
+import com.example.danggunmarket.member.exception.MemberNotFoundException;
 import com.example.danggunmarket.member.exception.WrongPasswordException;
 import com.example.danggunmarket.member.mapper.MemberMapper;
 import lombok.RequiredArgsConstructor;
@@ -40,8 +41,8 @@ public class MemberService {
     }
 
     public LoginResponse login(LoginRequest loginRequest) {
-        MemberEntity member = memberRepository.findById(1L)
-                .orElseThrow(() -> new WrongPasswordException(MemberErrorCode.NOT_MATCHED_PASSWORD));
+        MemberEntity member = memberRepository.findByEmail(loginRequest.getEmail())
+                .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.NOT_FOUND_MEMBER));
 
         if (!passwordEncoder.matches(loginRequest.getPassword(), member.getPassword())) {
             throw new WrongPasswordException(MemberErrorCode.NOT_MATCHED_PASSWORD);


### PR DESCRIPTION
- findById(1L) -> findByEmail("")로 수정
- http header에 토큰 담을 때 Bearer 를 붙이지 않는 거 수정
- memberEntity에서 id를 memberId로 수정
- memberId로 수정하면서 UserDetailsService에 getId()를 getMemberId()로 수정
- enum을 String으로 저장하도록 수정